### PR TITLE
Cleanup README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Commit since last release](https://img.shields.io/github/commits-since/apache/lucene-solr-operator/latest.svg)](https://github.com/apache/lucene-solr-operator/commits/master)
 [![Docker Pulls](https://img.shields.io/docker/pulls/bloomberg/solr-operator)](https://hub.docker.com/r/bloomberg/solr-operator/)
 [![Slack](https://img.shields.io/badge/slack-join_chat-white.svg?logo=slack&style=social)](https://kubernetes.slack.com/messages/solr-operator)
+[![Mailing List]]
 
 The __Solr Operator__ manages Apache Solr Clouds within Kubernetes. It is built on top of the [Kube Builder](https://github.com/kubernetes-sigs/kubebuilder) framework.
 
@@ -120,23 +121,15 @@ Have you had a good experience with the **Solr Operator**? Why not share some lo
 
 We welcome issue reports [here](../../issues); be sure to choose the proper issue template for your issue, so that we can be sure you're providing the necessary information.
 
-Before sending a [Pull Request](../../pulls), please make sure you read our
-[Contribution Guidelines](https://github.com/bloomberg/.github/blob/master/CONTRIBUTING.md).
-
 ## License
 
 Please read the [LICENSE](LICENSE) file here.
 
-## Code of Conduct
-
-This project has adopted a [Code of Conduct](https://github.com/bloomberg/.github/blob/master/CODE_OF_CONDUCT.md).
-If you have any concerns about the Code, or behavior which you have experienced in the project, please
-contact us at opensource@bloomberg.net.
-
 ## Security Vulnerability Reporting
 
-If you believe you have identified a security vulnerability in this project, please send email to the project
-team at opensource@bloomberg.net, detailing the suspected issue and any methods you've found to reproduce it.
+If you believe you have identified a security vulnerability in this project, please send email to the ASF security
+team at security@apache.org, detailing the suspected issue and any methods you've found to reproduce it. More details
+can be found [here](https://www.apache.org/security/)
 
 Please do NOT open an issue in the GitHub repository, as we'd prefer to keep vulnerability reports private until
 we've had an opportunity to review and address them.

--- a/README.md
+++ b/README.md
@@ -125,6 +125,12 @@ We welcome issue reports [here](../../issues); be sure to choose the proper issu
 
 Please read the [LICENSE](LICENSE) file here.
 
+## Code of Conduct
+
+This space applies the ASF [Code of Conduct](https://www.apache.org/foundation/policies/conduct)
+If you have any concerns about the Code, or behavior which you have experienced in the project, please
+contact us at private@lucene.apache.org .
+
 ## Security Vulnerability Reporting
 
 If you believe you have identified a security vulnerability in this project, please send email to the ASF security

--- a/docs/development.md
+++ b/docs/development.md
@@ -134,6 +134,3 @@ Make sure that you have updated the go.mod file:
 ```bash
 $ make mod-tidy
 ```
-
-Finally, as mentioned on the Repo's README, you will need to sign all commits included in the PR.
-More information can be found on the [organization's contibutions documentation](https://github.com/bloomberg/.github/blob/master/CONTRIBUTING.md#contribution-licensing).


### PR DESCRIPTION
Part of: #183 

Fix Bloomberg references.

Things pending:
- Docker Pulls - need to wait until we push an image to docker hub
- Slack - should we cross ref the Lucene/Solr one too?
- Contributing Guidelines - should we link this here? https://cwiki.apache.org/confluence/display/solr/HowToContribute ? This isn’t a 100% correct considering building and running are completely different for the operator. We need a new doc for this perhaps?