### PR TITLE
Update helm docs, and add link to new artifactHub.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Solr Operator
 [![Latest Version](https://img.shields.io/github/tag/apache/lucene-solr-operator)](https://github.com/apache/lucene-solr-operator/releases)
 [![License](https://img.shields.io/badge/LICENSE-Apache2.0-ff69b4.svg)](http://www.apache.org/licenses/LICENSE-2.0.html)
-[![Go Report Card](https://goreportcard.com/badge/github.com/apache/lucene-solr-operator)](https://goreportcard.com/report/github.com/apache/lucene-solr-operator)
+[![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/apache-solr)](https://artifacthub.io/packages/search?repo=apache-solr)
 [![Commit since last release](https://img.shields.io/github/commits-since/apache/lucene-solr-operator/latest.svg)](https://github.com/apache/lucene-solr-operator/commits/main)
 [![Docker Pulls](https://img.shields.io/docker/pulls/bloomberg/solr-operator)](https://hub.docker.com/r/bloomberg/solr-operator/)
 [![Slack](https://img.shields.io/badge/slack-join_chat-white.svg?logo=slack&style=social)](https://kubernetes.slack.com/messages/solr-operator)
@@ -32,6 +32,9 @@ Join us on the [#solr-operator](https://kubernetes.slack.com/messages/solr-opera
 Please visit the following pages for documentation on using and developing the Solr Operator:
 
 - [Local Tutorial](https://apache.github.io/lucene-solr-operator/docs/local_tutorial)
+- [Helm Instructions via Artifact Hub](https://artifacthub.io/packages/helm/apache-solr/solr-operator)
+  - The released helm charts and their instructions should be used for all safe and stable deployments.
+    The charts found in `helm/` are not guaranteed to be compatible with the last stable release, and should only be used for development purposes.
 - [Running the Solr Operator](https://apache.github.io/lucene-solr-operator/docs/running-the-operator)
 - Available Solr Resources
     - [Solr Clouds](https://apache.github.io/lucene-solr-operator/docs/solr-cloud)
@@ -46,6 +49,9 @@ Please visit the following pages for documentation on using and developing the S
 Example uses of each CRD have been [provided](https://apache.github.io/lucene-solr-operator/example).
 
 ## Version Compatibility & Upgrade Notes
+
+#### v0.3.0
+- All deprecated CRD fields and Solr Operator options from `v0.2.*` have been removed.
 
 #### v0.2.7
 - Do to the addition of possible sidecar/initContainers for SolrClouds, the version of CRDs used had to be upgraded to `apiextensions.k8s.io/v1`.

--- a/docs/local_tutorial.md
+++ b/docs/local_tutorial.md
@@ -56,6 +56,8 @@ Once we have installed Solr to our k8s, this will allow us to address the nodes 
 
 ## Install the Solr Operator
 
+You can follow along here, or follow the instructions in the [Official Helm release](https://artifacthub.io/packages/helm/apache-solr/solr-operator).
+
 Now that we have the prerequisites setup, let us install Solr Operator which will let us easily manage a large Solr cluster:
 
 Before installing the Solr Operator, we need to install the [Zookeeper Operator](https://github.com/pravega/zookeeper-operator).
@@ -68,14 +70,14 @@ kubectl apply -f https://apache.github.io/lucene-solr-operator/example/dependenc
 Now add the Solr Operator Helm repository. (You should only need to do this once)
 
 ```bash
-$ helm repo add solr-operator https://apache.github.io/lucene-solr-operator/charts
+$ helm repo add apache-solr https://apache.github.io/lucene-solr-operator/charts
 ```
 
 Next, install the Solr Operator chart. Note this is using Helm v3, in order to use Helm v2 please consult the [Helm Chart documentation](https://hub.helm.sh/charts/solr-operator/solr-operator).
 
 ```bash
 # Install the operator
-$ helm install solr-operator solr-operator/solr-operator
+$ helm install solr-operator apache-solr/solr-operator
 ```
 
 After installing, you can check to see what lives in the cluster to make sure that the Solr and ZooKeeper operators have started correctly.

--- a/docs/running-the-operator.md
+++ b/docs/running-the-operator.md
@@ -18,17 +18,19 @@ The helm chart provides abstractions over the Input Arguments described below, a
 
 ### How to install via Helm
 
+The official documenation for installing the Solr Operator Helm chart can be found on [Artifact Hub](https://artifacthub.io/packages/helm/apache-solr/solr-operator).
+
 The first step is to add the Solr Operator helm repository.
 
 ```bash
-$ helm repo add solr-operator https://apache.github.io/lucene-solr-operator/charts
+$ helm repo add apache-solr https://apache.github.io/lucene-solr-operator/charts
 ```
 
 
-Next, install the Solr Operator chart. Note this is using Helm v3, in order to use Helm v2 please consult the [Helm Chart documentation](https://hub.helm.sh/charts/solr-operator/solr-operator).
+Next, install the Solr Operator chart. Note this is using Helm v3, use the official Helm chart documentation linked to above.
 
 ```bash
-$ helm install solr-operator solr-operator/solr-operator
+$ helm install solr-operator apache-solr/solr-operator
 ```
 
 After installing, you can check to see what lives in the cluster to make sure that the Solr and ZooKeeper operators have started correctly.

--- a/helm/solr-operator/Chart.yaml
+++ b/helm/solr-operator/Chart.yaml
@@ -34,3 +34,65 @@ maintainers:
   - name: Houston Putman
     email: houston@apache.org
 icon: https://lucene.apache.org/theme/images/solr/identity/Solr_Logo_on_white.png
+annotations:
+  artifacthub.io/operator: "true"
+  artifacthub.io/operatorCapabilities: Seamless Upgrades
+  artifacthub.io/prerelease: "false"
+  artifacthub.io/images: |
+    - name: solr-operator
+      image: apache/solr-operator:v0.2.8
+  artifacthub.io/crds: |
+    - kind: SolrCloud
+      version: v1beta1
+      name: solrcloud.solr.apache.org
+      displayName: Solr Cloud
+      description: A distributed Solr Cloud cluster
+    - kind: SolrPrometheusExporter
+      version: v1beta1
+      name: solrprometheusexporter.solr.apache.org
+      displayName: Solr Prometheus Exporter
+      description: A Prometheus metrics exporter for Solr
+    - kind: SolrBackup
+      version: v1beta1
+      name: solrbackup.solr.apache.org
+      displayName: Solr Backup
+      description: A backup mechanism for Solr
+  artifacthub.io/crdsExamples: |
+    - apiVersion: solr.apache.org/v1beta1
+      kind: SolrCloud
+      metadata:
+        name: example
+      spec:
+        dataStorage:
+          persistent:
+            reclaimPolicy: Delete
+            pvcTemplate:
+              spec:
+                resources:
+                  requests:
+                    storage: "20Gi"
+        replicas: 3
+        solrImage:
+          tag: 8.7.0
+        solrJavaMem: "-Xms4g -Xmx4g"
+        customSolrKubeOptions:
+          podOptions:
+            resources:
+              requests:
+                memory: "6G"
+        zookeeperRef:
+          provided:
+            replicas: 3
+        solrOpts: "-Dsolr.autoSoftCommit.maxTime=10000"
+        solrGCTune: "-XX:SurvivorRatio=4 -XX:TargetSurvivorRatio=90 -XX:MaxTenuringThreshold=8"
+    - apiVersion: solr.apache.org/v1beta1
+      kind: SolrPrometheusExporter
+      metadata:
+        name: example
+      spec:
+        solrReference:
+          cloud:
+            name: "example"
+        numThreads: 4
+        image:
+          tag: 8.7.0

--- a/helm/solr-operator/README.md
+++ b/helm/solr-operator/README.md
@@ -34,7 +34,7 @@ kubectl apply -f https://apache.github.io/lucene-solr-operator/example/dependenc
 You should only need to add the solr operator helm chart repository once, by running the following command:
 
 ```console
-$ helm repo add solr-operator https://apache.github.io/lucene-solr-operator/charts
+$ helm repo add apache-solr https://apache.github.io/lucene-solr-operator/charts
 ```
 
 ### Installing the Chart
@@ -42,8 +42,8 @@ $ helm repo add solr-operator https://apache.github.io/lucene-solr-operator/char
 To install the Solr Operator with the latest version or with a specific version, run either of the following commands:
 
 ```console
-$ helm install solr-operator solr-operator/solr-operator
-$ helm install solr-operator solr-operator/solr-operator --version 0.2.5
+$ helm install solr-operator apache-solr/solr-operator
+$ helm install solr-operator apache-solr/solr-operator --version 0.2.5
 ```
 
 The command deploys the solr-operator on the Kubernetes cluster with the default configuration.
@@ -55,21 +55,21 @@ If you want to specify the namespace for the installation, use the `--namespace`
 All resources will be deployed to the given namespace.
 
 ```console
-$ helm install solr-operator solr-operator/solr-operator --namespace solr
+$ helm install solr-operator apache-solr/solr-operator --namespace solr
 ```
 
 If you want to only watch that namespace, or others, then you will have to provide the `watchNamespaces` option.
 
 ```console
 // Watch the namespace where the operator is deployed to (just pass the boolean true)
-$ helm install solr-operator solr-operator/solr-operator --namespace solr --set watchNamespaces=true
+$ helm install solr-operator apache-solr/solr-operator --namespace solr --set watchNamespaces=true
 // Watch a single namespace different than the one being deployed to
-$ helm install solr-operator solr-operator/solr-operator --namespace solr --set watchNamespaces=other
+$ helm install solr-operator apache-solr/solr-operator --namespace solr --set watchNamespaces=other
 // Watch multiple namespaces (commmas must be escaped in the set string)
-$ helm install solr-operator solr-operator/solr-operator --namespace solr --set watchNamespaces="team1\,team2\,team3"
+$ helm install solr-operator apache-solr/solr-operator --namespace solr --set watchNamespaces="team1\,team2\,team3"
 ```
 
-Note: Passing `false` and `""` to the `watchNamespaces` variable will both result in the operator watchting all namespaces in the Kube cluster.
+Note: Passing `false` or `""` to the `watchNamespaces` variable will both result in the operator watchting all namespaces in the Kube cluster.
 
 ### Managing CRDs
 
@@ -81,7 +81,7 @@ If have solr operator installations in multiple namespaces that are managed sepa
 This can be done with the `--skip-crds` helm option.
 
 ```console
-$ helm install solr-operator solr-operator/solr-operator --skip-crds --namespace solr
+$ helm install solr-operator apache-solr/solr-operator --skip-crds --namespace solr
 ```
 
 #### Helm 2
@@ -91,7 +91,7 @@ If you are using Helm 2, CRDs are installed using the crd-install hook. Prior to
 You will also need to update the install command to use the name flag, as shown below.
 
 ```console
-$ helm install --name solr-operator solr-operator/solr-operator
+$ helm install --name solr-operator apache-solr/solr-operator
 ```
 
 ### Uninstalling the Chart


### PR DESCRIPTION
A part of #183 .

This is a stable artifactHub location, and will not change whenever the repo moves.

The artifactHub will also contain the docs for released Helm chart images, so users will not have to use the unstable documentation at `/helm`.

I will be going and backporting documentation for old helm charts to update urls that are no longer available.