### PR TITLE
NT: Allow the definition of multiple imagePullSecrets.

### DIFF
--- a/api/v1beta1/common_types.go
+++ b/api/v1beta1/common_types.go
@@ -118,6 +118,12 @@ type PodOptions struct {
 	// These will run along with the init container that sets up the "solr.xml".
 	// +optional
 	InitContainers []corev1.Container `json:"initContainers,omitempty"`
+
+	// ImagePullSecrets to apply to the pod.
+	// These are for init/sidecarContainers in addition to the imagePullSecret defined for the
+	// solr image.
+	// +optional
+	ImagePullSecrets []corev1.LocalObjectReference `json:"imagePullSecrets,omitempty"`
 }
 
 // ServiceOptions defines custom options for services

--- a/config/crd/bases/solr.apache.org_solrclouds.yaml
+++ b/config/crd/bases/solr.apache.org_solrclouds.yaml
@@ -580,6 +580,16 @@ spec:
                           - name
                           type: object
                         type: array
+                      imagePullSecrets:
+                        description: ImagePullSecrets to apply to the pod. These are for init/sidecarContainers in addition to the imagePullSecret defined for the solr image.
+                        items:
+                          description: LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          type: object
+                        type: array
                       initContainers:
                         description: Additional init containers to run in the pod. These will run along with the init container that sets up the "solr.xml".
                         items:

--- a/config/crd/bases/solr.apache.org_solrprometheusexporters.yaml
+++ b/config/crd/bases/solr.apache.org_solrprometheusexporters.yaml
@@ -509,6 +509,16 @@ spec:
                           - name
                           type: object
                         type: array
+                      imagePullSecrets:
+                        description: ImagePullSecrets to apply to the pod. These are for init/sidecarContainers in addition to the imagePullSecret defined for the solr image.
+                        items:
+                          description: LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          type: object
+                        type: array
                       initContainers:
                         description: Additional init containers to run in the pod. These will run along with the init container that sets up the "solr.xml".
                         items:

--- a/controllers/controller_utils_test.go
+++ b/controllers/controller_utils_test.go
@@ -531,8 +531,13 @@ var (
 			Operator: "Exists",
 		},
 	}
-	testPriorityClass = "p4"
-	extraVars         = []corev1.EnvVar{
+	testPriorityClass              = "p4"
+	testImagePullSecretName        = "MAIN_SECRET"
+	testAdditionalImagePullSecrets = []corev1.LocalObjectReference{
+		{Name: "ADDITIONAL_SECRET_1"},
+		{Name: "ADDITIONAL_SECRET_2"},
+	}
+	extraVars = []corev1.EnvVar{
 		{
 			Name:  "VAR_1",
 			Value: "VAL_1",

--- a/controllers/solrcloud_controller_test.go
+++ b/controllers/solrcloud_controller_test.go
@@ -174,6 +174,9 @@ func TestCustomKubeOptionsCloudReconcile(t *testing.T) {
 			Labels:    map[string]string{"base": "here"},
 		},
 		Spec: solr.SolrCloudSpec{
+			SolrImage: &solr.ContainerImage{
+				ImagePullSecret: testImagePullSecretName,
+			},
 			Replicas: &replicas,
 			ZookeeperRef: &solr.ZookeeperRef{
 				ConnectionInfo: &solr.ZookeeperConnectionInfo{
@@ -194,6 +197,7 @@ func TestCustomKubeOptionsCloudReconcile(t *testing.T) {
 					ReadinessProbe:    testProbeReadinessNonDefaults,
 					StartupProbe:      testProbeStartup,
 					PriorityClassName: testPriorityClass,
+					ImagePullSecrets:  testAdditionalImagePullSecrets,
 				},
 				StatefulSetOptions: &solr.StatefulSetOptions{
 					Annotations:         testSSAnnotations,
@@ -278,6 +282,7 @@ func TestCustomKubeOptionsCloudReconcile(t *testing.T) {
 	assert.Equal(t, []string{"solr", "stop", "-p", "8983"}, statefulSet.Spec.Template.Spec.Containers[0].Lifecycle.PreStop.Exec.Command, "Incorrect pre-stop command")
 	testPodTolerations(t, testTolerations, statefulSet.Spec.Template.Spec.Tolerations)
 	assert.EqualValues(t, testPriorityClass, statefulSet.Spec.Template.Spec.PriorityClassName, "Incorrect Priority class name for Pod Spec")
+	assert.ElementsMatch(t, append(testAdditionalImagePullSecrets, corev1.LocalObjectReference{Name: testImagePullSecretName}), statefulSet.Spec.Template.Spec.ImagePullSecrets, "Incorrect imagePullSecrets")
 
 	// Check the update strategy
 	assert.EqualValues(t, appsv1.RollingUpdateStatefulSetStrategyType, statefulSet.Spec.UpdateStrategy.Type, "Incorrect statefulset update strategy")

--- a/controllers/solrprometheusexporter_controller_test.go
+++ b/controllers/solrprometheusexporter_controller_test.go
@@ -63,9 +63,13 @@ func TestMetricsReconcileWithoutExporterConfig(t *testing.T) {
 					Resources:          resources,
 					SidecarContainers:  extraContainers2,
 					InitContainers:     extraContainers1,
+					ImagePullSecrets:   testAdditionalImagePullSecrets,
 				},
 			},
 			ExporterEntrypoint: "/test/entry-point",
+			Image: &solr.ContainerImage{
+				ImagePullSecret: testImagePullSecretName,
+			},
 		},
 	}
 
@@ -124,6 +128,7 @@ func TestMetricsReconcileWithoutExporterConfig(t *testing.T) {
 	assert.Equal(t, len(extraVolumes), len(deployment.Spec.Template.Spec.Volumes), "Pod has wrong number of volumes")
 	assert.Equal(t, extraVolumes[0].Name, deployment.Spec.Template.Spec.Volumes[0].Name, "Additional Volume from podOptions not loaded into pod properly.")
 	assert.Equal(t, extraVolumes[0].Source, deployment.Spec.Template.Spec.Volumes[0].VolumeSource, "Additional Volume from podOptions not loaded into pod properly.")
+	assert.ElementsMatch(t, append(testAdditionalImagePullSecrets, corev1.LocalObjectReference{Name: testImagePullSecretName}), deployment.Spec.Template.Spec.ImagePullSecrets, "Incorrect imagePullSecrets")
 
 	service := expectService(t, g, requests, expectedMetricsRequest, metricsSKey, deployment.Spec.Template.Labels)
 	assert.Equal(t, "true", service.Annotations["prometheus.io/scrape"], "Metrics Service Prometheus scraping is not enabled.")

--- a/controllers/util/prometheus_exporter_util.go
+++ b/controllers/util/prometheus_exporter_util.go
@@ -69,6 +69,7 @@ func GenerateSolrPrometheusExporterDeployment(solrPrometheusExporter *solr.SolrP
 
 	podLabels := labels
 	var podAnnotations map[string]string
+	var imagePullSecrets []corev1.LocalObjectReference
 
 	customDeploymentOptions := solrPrometheusExporter.Spec.CustomKubeOptions.DeploymentOptions
 	if nil != customDeploymentOptions {
@@ -80,6 +81,7 @@ func GenerateSolrPrometheusExporterDeployment(solrPrometheusExporter *solr.SolrP
 	if nil != customPodOptions {
 		podLabels = MergeLabelsOrAnnotations(podLabels, customPodOptions.Labels)
 		podAnnotations = customPodOptions.Annotations
+		imagePullSecrets = customPodOptions.ImagePullSecrets
 	}
 
 	var envVars []corev1.EnvVar
@@ -274,10 +276,13 @@ func GenerateSolrPrometheusExporterDeployment(solrPrometheusExporter *solr.SolrP
 	}
 
 	if solrPrometheusExporter.Spec.Image.ImagePullSecret != "" {
-		deployment.Spec.Template.Spec.ImagePullSecrets = []corev1.LocalObjectReference{
-			{Name: solrPrometheusExporter.Spec.Image.ImagePullSecret},
-		}
+		imagePullSecrets = append(
+			imagePullSecrets,
+			corev1.LocalObjectReference{Name: solrPrometheusExporter.Spec.Image.ImagePullSecret},
+		)
 	}
+
+	deployment.Spec.Template.Spec.ImagePullSecrets = imagePullSecrets
 
 	if nil != customPodOptions {
 		if customPodOptions.Affinity != nil {

--- a/controllers/util/solr_util.go
+++ b/controllers/util/solr_util.go
@@ -19,15 +19,16 @@ package util
 
 import (
 	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
 	solr "github.com/apache/lucene-solr-operator/api/v1beta1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	extv1 "k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"sort"
-	"strconv"
-	"strings"
 )
 
 const (
@@ -519,11 +520,20 @@ func GenerateStatefulSet(solrCloud *solr.SolrCloud, solrCloudStatus *solr.SolrCl
 		},
 	}
 
-	if solrCloud.Spec.SolrImage.ImagePullSecret != "" {
-		stateful.Spec.Template.Spec.ImagePullSecrets = []corev1.LocalObjectReference{
-			{Name: solrCloud.Spec.SolrImage.ImagePullSecret},
-		}
+	var imagePullSecrets []corev1.LocalObjectReference
+
+	if customPodOptions != nil {
+		imagePullSecrets = customPodOptions.ImagePullSecrets
 	}
+
+	if solrCloud.Spec.SolrImage.ImagePullSecret != "" {
+		imagePullSecrets = append(
+			imagePullSecrets,
+			corev1.LocalObjectReference{Name: solrCloud.Spec.SolrImage.ImagePullSecret},
+		)
+	}
+
+	stateful.Spec.Template.Spec.ImagePullSecrets = imagePullSecrets
 
 	if nil != customPodOptions {
 		if customPodOptions.Affinity != nil {

--- a/controllers/util/solr_util.go
+++ b/controllers/util/solr_util.go
@@ -19,16 +19,15 @@ package util
 
 import (
 	"fmt"
-	"sort"
-	"strconv"
-	"strings"
-
 	solr "github.com/apache/lucene-solr-operator/api/v1beta1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	extv1 "k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"sort"
+	"strconv"
+	"strings"
 )
 
 const (

--- a/go.sum
+++ b/go.sum
@@ -408,6 +408,7 @@ github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkU
 github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
 github.com/spf13/cobra v0.0.5 h1:f0B+LkLX6DtmRH1isoNA9VTtNUK9K8xYd28JNNfOv/s=
 github.com/spf13/cobra v0.0.5/go.mod h1:3K3wKZymM7VvHMDS9+Akkh4K60UwM26emMESw8tLCHU=
+github.com/spf13/cobra v1.0.0 h1:6m/oheQuQ13N9ks4hubMG6BnvwOeaJrqSPLahSnczz8=
 github.com/spf13/cobra v1.0.0/go.mod h1:/6GTrnGXV9HjY+aR4k0oJ5tcvakLuG6EuKReYlHNrgE=
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
 github.com/spf13/pflag v0.0.0-20170130214245-9ff6c6923cff/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=

--- a/helm/solr-operator/crds/crds.yaml
+++ b/helm/solr-operator/crds/crds.yaml
@@ -1721,6 +1721,16 @@ spec:
                           - name
                           type: object
                         type: array
+                      imagePullSecrets:
+                        description: ImagePullSecrets to apply to the pod. These are for init/sidecarContainers in addition to the imagePullSecret defined for the solr image.
+                        items:
+                          description: LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          type: object
+                        type: array
                       initContainers:
                         description: Additional init containers to run in the pod. These will run along with the init container that sets up the "solr.xml".
                         items:
@@ -6936,6 +6946,16 @@ spec:
                               type: object
                           required:
                           - name
+                          type: object
+                        type: array
+                      imagePullSecrets:
+                        description: ImagePullSecrets to apply to the pod. These are for init/sidecarContainers in addition to the imagePullSecret defined for the solr image.
+                        items:
+                          description: LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
                           type: object
                         type: array
                       initContainers:


### PR DESCRIPTION
Currently you can only specify a single imagePullSecret in the ContainerImage, for the SolrImage in SolrCloudSpec. This allows a user to define any number of imagePullSecrets, which is required if initContainers or sidecarContainers need different imagePullSecrets to the SolrImage.