### PR TITLE
Use k8s.io/api/networking/v1beta1 Ingress.

### DIFF
--- a/controllers/solrcloud_controller.go
+++ b/controllers/solrcloud_controller.go
@@ -27,7 +27,7 @@ import (
 	zk "github.com/pravega/zookeeper-operator/pkg/apis/zookeeper/v1beta1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	extv1 "k8s.io/api/extensions/v1beta1"
+	netv1 "k8s.io/api/networking/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -406,7 +406,7 @@ func (r *SolrCloudReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 
 		// Check if the Ingress already exists
 		ingressLogger := logger.WithValues("ingress", ingress.Name)
-		foundIngress := &extv1.Ingress{}
+		foundIngress := &netv1.Ingress{}
 		err = r.Get(context.TODO(), types.NamespacedName{Name: ingress.Name, Namespace: ingress.Namespace}, foundIngress)
 		if err != nil && errors.IsNotFound(err) {
 			ingressLogger.Info("Creating Ingress")
@@ -755,7 +755,7 @@ func (r *SolrCloudReconciler) SetupWithManagerAndReconciler(mgr ctrl.Manager, re
 		Owns(&corev1.ConfigMap{}).
 		Owns(&appsv1.StatefulSet{}).
 		Owns(&corev1.Service{}).
-		Owns(&extv1.Ingress{})
+		Owns(&netv1.Ingress{})
 
 	var err error
 	ctrlBuilder, err = r.indexAndWatchForProvidedConfigMaps(mgr, ctrlBuilder)

--- a/controllers/solrcloud_controller_tls_test.go
+++ b/controllers/solrcloud_controller_tls_test.go
@@ -28,7 +28,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
-	extv1 "k8s.io/api/extensions/v1beta1"
+	netv1 "k8s.io/api/networking/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -236,7 +236,7 @@ func expectStatefulSetTLSConfig(t *testing.T, g *gomega.GomegaWithT, sc *solr.So
 }
 
 func expectIngressTLSConfig(t *testing.T, g *gomega.GomegaWithT, expectedTLSSecretName string) {
-	ingress := &extv1.Ingress{}
+	ingress := &netv1.Ingress{}
 	g.Eventually(func() error { return testClient.Get(context.TODO(), expectedIngressWithTLS, ingress) }, timeout).Should(gomega.Succeed())
 	assert.True(t, ingress.Spec.TLS != nil && len(ingress.Spec.TLS) == 1)
 	assert.Equal(t, expectedTLSSecretName, ingress.Spec.TLS[0].SecretName)

--- a/controllers/util/common.go
+++ b/controllers/util/common.go
@@ -21,7 +21,7 @@ import (
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	extv1 "k8s.io/api/extensions/v1beta1"
+	netv1 "k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"reflect"
 	"strconv"
@@ -180,7 +180,7 @@ func CopyServiceFields(from, to *corev1.Service, logger logr.Logger) bool {
 }
 
 // CopyIngressFields copies the owned fields from one Ingress to another
-func CopyIngressFields(from, to *extv1.Ingress, logger logr.Logger) bool {
+func CopyIngressFields(from, to *netv1.Ingress, logger logr.Logger) bool {
 	logger = logger.WithValues("kind", "ingress")
 	requireUpdate := CopyLabelsAndAnnotations(&from.ObjectMeta, &to.ObjectMeta, logger)
 

--- a/controllers/util/prometheus_exporter_util.go
+++ b/controllers/util/prometheus_exporter_util.go
@@ -21,7 +21,7 @@ import (
 	solr "github.com/apache/lucene-solr-operator/api/v1beta1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	extv1 "k8s.io/api/extensions/v1beta1"
+	netv1 "k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"strconv"
@@ -386,18 +386,20 @@ func GenerateSolrMetricsService(solrPrometheusExporter *solr.SolrPrometheusExpor
 // solrCloud: SolrCloud instance
 // nodeName: string Name of the node
 // ingressBaseDomain: string base domain for the ingress controller
-func CreateMetricsIngressRule(solrPrometheusExporter *solr.SolrPrometheusExporter, ingressBaseDomain string) extv1.IngressRule {
+func CreateMetricsIngressRule(solrPrometheusExporter *solr.SolrPrometheusExporter, ingressBaseDomain string) netv1.IngressRule {
+	pathType := netv1.PathTypeImplementationSpecific
 	externalAddress := solrPrometheusExporter.MetricsIngressUrl(ingressBaseDomain)
-	return extv1.IngressRule{
+	return netv1.IngressRule{
 		Host: externalAddress,
-		IngressRuleValue: extv1.IngressRuleValue{
-			HTTP: &extv1.HTTPIngressRuleValue{
-				Paths: []extv1.HTTPIngressPath{
+		IngressRuleValue: netv1.IngressRuleValue{
+			HTTP: &netv1.HTTPIngressRuleValue{
+				Paths: []netv1.HTTPIngressPath{
 					{
-						Backend: extv1.IngressBackend{
+						Backend: netv1.IngressBackend{
 							ServiceName: solrPrometheusExporter.MetricsServiceName(),
 							ServicePort: intstr.FromInt(ExtSolrMetricsPort),
 						},
+						PathType: &pathType,
 					},
 				},
 			},

--- a/controllers/util/solr_util.go
+++ b/controllers/util/solr_util.go
@@ -22,7 +22,7 @@ import (
 	solr "github.com/apache/lucene-solr-operator/api/v1beta1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	extv1 "k8s.io/api/extensions/v1beta1"
+	netv1 "k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sort"
@@ -828,7 +828,7 @@ func GenerateNodeService(solrCloud *solr.SolrCloud, nodeName string) *corev1.Ser
 // GenerateIngress returns a new Ingress pointer generated for the entire SolrCloud, pointing to all instances
 // solrCloud: SolrCloud instance
 // nodeStatuses: []SolrNodeStatus the nodeStatuses
-func GenerateIngress(solrCloud *solr.SolrCloud, nodeNames []string) (ingress *extv1.Ingress) {
+func GenerateIngress(solrCloud *solr.SolrCloud, nodeNames []string) (ingress *netv1.Ingress) {
 	labels := solrCloud.SharedLabelsWith(solrCloud.GetLabels())
 	var annotations map[string]string
 
@@ -843,7 +843,7 @@ func GenerateIngress(solrCloud *solr.SolrCloud, nodeNames []string) (ingress *ex
 	// Create advertised domain name and possible additional domain names
 	rules := CreateSolrIngressRules(solrCloud, nodeNames, append([]string{extOpts.DomainName}, extOpts.AdditionalDomainNames...))
 
-	var ingressTLS []extv1.IngressTLS
+	var ingressTLS []netv1.IngressTLS
 	if solrCloud.Spec.SolrTLS != nil {
 		if annotations == nil {
 			annotations = make(map[string]string, 1)
@@ -852,17 +852,17 @@ func GenerateIngress(solrCloud *solr.SolrCloud, nodeNames []string) (ingress *ex
 		if !ok {
 			annotations["nginx.ingress.kubernetes.io/backend-protocol"] = "HTTPS"
 		}
-		ingressTLS = append(ingressTLS, extv1.IngressTLS{SecretName: solrCloud.Spec.SolrTLS.PKCS12Secret.Name})
+		ingressTLS = append(ingressTLS, netv1.IngressTLS{SecretName: solrCloud.Spec.SolrTLS.PKCS12Secret.Name})
 	}
 
-	ingress = &extv1.Ingress{
+	ingress = &netv1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        solrCloud.CommonIngressName(),
 			Namespace:   solrCloud.GetNamespace(),
 			Labels:      labels,
 			Annotations: annotations,
 		},
-		Spec: extv1.IngressSpec{
+		Spec: netv1.IngressSpec{
 			Rules: rules,
 			TLS:   ingressTLS,
 		},
@@ -874,8 +874,8 @@ func GenerateIngress(solrCloud *solr.SolrCloud, nodeNames []string) (ingress *ex
 // solrCloud: SolrCloud instance
 // nodeNames: the names for each of the solr pods
 // domainName: string Domain for the ingress rule to use
-func CreateSolrIngressRules(solrCloud *solr.SolrCloud, nodeNames []string, domainNames []string) []extv1.IngressRule {
-	var ingressRules []extv1.IngressRule
+func CreateSolrIngressRules(solrCloud *solr.SolrCloud, nodeNames []string, domainNames []string) []netv1.IngressRule {
+	var ingressRules []netv1.IngressRule
 	if !solrCloud.Spec.SolrAddressability.External.HideCommon {
 		for _, domainName := range domainNames {
 			ingressRules = append(ingressRules, CreateCommonIngressRule(solrCloud, domainName))
@@ -894,15 +894,15 @@ func CreateSolrIngressRules(solrCloud *solr.SolrCloud, nodeNames []string, domai
 // CreateCommonIngressRule returns a new Ingress Rule generated for a SolrCloud under the given domainName
 // solrCloud: SolrCloud instance
 // domainName: string Domain for the ingress rule to use
-func CreateCommonIngressRule(solrCloud *solr.SolrCloud, domainName string) (ingressRule extv1.IngressRule) {
-	pathType := extv1.PathTypeImplementationSpecific
-	ingressRule = extv1.IngressRule{
+func CreateCommonIngressRule(solrCloud *solr.SolrCloud, domainName string) (ingressRule netv1.IngressRule) {
+	pathType := netv1.PathTypeImplementationSpecific
+	ingressRule = netv1.IngressRule{
 		Host: solrCloud.ExternalCommonUrl(domainName, false),
-		IngressRuleValue: extv1.IngressRuleValue{
-			HTTP: &extv1.HTTPIngressRuleValue{
-				Paths: []extv1.HTTPIngressPath{
+		IngressRuleValue: netv1.IngressRuleValue{
+			HTTP: &netv1.HTTPIngressRuleValue{
+				Paths: []netv1.HTTPIngressPath{
 					{
-						Backend: extv1.IngressBackend{
+						Backend: netv1.IngressBackend{
 							ServiceName: solrCloud.CommonServiceName(),
 							ServicePort: intstr.FromInt(solrCloud.Spec.SolrAddressability.CommonServicePort),
 						},
@@ -919,15 +919,15 @@ func CreateCommonIngressRule(solrCloud *solr.SolrCloud, domainName string) (ingr
 // solrCloud: SolrCloud instance
 // nodeName: string Name of the node
 // domainName: string Domain for the ingress rule to use
-func CreateNodeIngressRule(solrCloud *solr.SolrCloud, nodeName string, domainName string) (ingressRule extv1.IngressRule) {
-	pathType := extv1.PathTypeImplementationSpecific
-	ingressRule = extv1.IngressRule{
+func CreateNodeIngressRule(solrCloud *solr.SolrCloud, nodeName string, domainName string) (ingressRule netv1.IngressRule) {
+	pathType := netv1.PathTypeImplementationSpecific
+	ingressRule = netv1.IngressRule{
 		Host: solrCloud.ExternalNodeUrl(nodeName, domainName, false),
-		IngressRuleValue: extv1.IngressRuleValue{
-			HTTP: &extv1.HTTPIngressRuleValue{
-				Paths: []extv1.HTTPIngressPath{
+		IngressRuleValue: netv1.IngressRuleValue{
+			HTTP: &netv1.HTTPIngressRuleValue{
+				Paths: []netv1.HTTPIngressPath{
 					{
-						Backend: extv1.IngressBackend{
+						Backend: netv1.IngressBackend{
 							ServiceName: nodeName,
 							ServicePort: intstr.FromInt(solrCloud.NodePort()),
 						},

--- a/go.sum
+++ b/go.sum
@@ -408,6 +408,7 @@ github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkU
 github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
 github.com/spf13/cobra v0.0.5 h1:f0B+LkLX6DtmRH1isoNA9VTtNUK9K8xYd28JNNfOv/s=
 github.com/spf13/cobra v0.0.5/go.mod h1:3K3wKZymM7VvHMDS9+Akkh4K60UwM26emMESw8tLCHU=
+github.com/spf13/cobra v1.0.0 h1:6m/oheQuQ13N9ks4hubMG6BnvwOeaJrqSPLahSnczz8=
 github.com/spf13/cobra v1.0.0/go.mod h1:/6GTrnGXV9HjY+aR4k0oJ5tcvakLuG6EuKReYlHNrgE=
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
 github.com/spf13/pflag v0.0.0-20170130214245-9ff6c6923cff/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=


### PR DESCRIPTION
Resolves #214 

Replaces the _k8s.io/api/extensions/v1beta1_ `Ingress` with the _k8s.io/api/networking/v1beta1_ `Ingress`.

Initially I tried to replace with _k8s.io/api/networking/v1_, however that is not stable until Kubernetes v1.19. So we will want to wait to upgrade to v1 until our minimum supported Kubernetes version is v1.19.