### PR TITLE
Update the owner reference of owned resources, if the reference is not correct

### DIFF
--- a/controllers/util/common.go
+++ b/controllers/util/common.go
@@ -23,7 +23,10 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	netv1 "k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/pointer"
 	"reflect"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"strconv"
 	"strings"
 )
@@ -529,4 +532,18 @@ func CopyPodContainers(fromPtr, toPtr *[]corev1.Container, basePath string, logg
 		}
 	}
 	return requireUpdate
+}
+
+// OvertakeControllerRef makes sure that the controlled object has the owner as the controller ref.
+// If the object has a different controller, then that ref will be downgraded to an "owner" and the new controller ref will be added
+func OvertakeControllerRef(owner metav1.Object, controlled metav1.Object, scheme *runtime.Scheme) (needsUpdate bool, err error) {
+	if !metav1.IsControlledBy(controlled, owner) {
+		if otherController := metav1.GetControllerOfNoCopy(controlled); otherController != nil {
+			otherController.Controller = pointer.BoolPtr(false)
+			otherController.BlockOwnerDeletion = pointer.BoolPtr(false)
+		}
+		err = controllerutil.SetControllerReference(owner, controlled, scheme)
+		needsUpdate = true
+	}
+	return needsUpdate, err
 }

--- a/go.mod
+++ b/go.mod
@@ -22,5 +22,6 @@ require (
 	k8s.io/apimachinery v0.19.0
 	k8s.io/client-go v0.19.0
 	k8s.io/klog/v2 v2.3.0 // indirect
+	k8s.io/utils v0.0.0-20200729134348-d5654de09c73
 	sigs.k8s.io/controller-runtime v0.6.2
 )


### PR DESCRIPTION
Relates to #222 

This change is necessary if in-place updates from Bloomberg resources to Apache resources are to succeed.

With this change, resources created for Bloomberg SolrClouds can be claimed and re-controlled by Apache SolrClouds.

This does make new resource management code more complex, but it is a good feature to have, probably.